### PR TITLE
Add ../../lib/libdns.a to some places to fix linking errors

### DIFF
--- a/postfix/src/postscreen/Makefile.in
+++ b/postfix/src/postscreen/Makefile.in
@@ -17,7 +17,7 @@ TESTPROG=
 PROG	= postscreen
 INC_DIR = ../../include
 LIBS	= ../../lib/libmaster.a ../../lib/libtls.a ../../lib/libglobal.a \
-	../../lib/libutil.a
+	../../lib/libutil.a ../../lib/libdns.a
 
 .c.o:;	$(CC) $(CFLAGS) -c $*.c
 

--- a/postfix/src/tls/Makefile.in
+++ b/postfix/src/tls/Makefile.in
@@ -19,7 +19,7 @@ INCL	=
 LIB	= libtls.a
 TESTPROG= tls_dh tls_mgr
 
-LIBS	= ../../lib/libglobal.a ../../lib/libutil.a
+LIBS	= ../../lib/libglobal.a ../../lib/libutil.a ../../lib/libdns.a
 LIB_DIR	= ../../lib
 INC_DIR	= ../../include
 MAKES	=

--- a/postfix/src/tlsmgr/Makefile.in
+++ b/postfix/src/tlsmgr/Makefile.in
@@ -9,7 +9,7 @@ TESTPROG=
 PROG	= tlsmgr
 INC_DIR	= ../../include
 LIBS	= ../../lib/libmaster.a ../../lib/libtls.a ../../lib/libglobal.a \
-	../../lib/libutil.a
+	../../lib/libutil.a ../../lib/libdns.a
 
 .c.o:;	$(CC) $(CFLAGS) -c $*.c
 

--- a/postfix/src/tlsproxy/Makefile.in
+++ b/postfix/src/tlsproxy/Makefile.in
@@ -9,7 +9,7 @@ TESTPROG=
 PROG	= tlsproxy
 INC_DIR = ../../include
 LIBS	= ../../lib/libtls.a ../../lib/libmaster.a ../../lib/libglobal.a \
-	../../lib/libutil.a
+	../../lib/libutil.a ../../lib/libdns.a
 
 .c.o:;	$(CC) $(CFLAGS) -c $*.c
 


### PR DESCRIPTION
It might be because of the Debian patch (which changes some linking), but I need this patch to stop seeing missing symbols on several places.

Could you please review (and possibly merge)?
