### PR TITLE
Add support for {client_helo} milter macro.

### DIFF
--- a/postfix/html/MILTER_README.html
+++ b/postfix/html/MILTER_README.html
@@ -661,6 +661,9 @@ verification fails: "unknown" </td> </tr>
 <td> Client name from address &rarr; name lookup <br> When address
 &rarr; name lookup fails: "unknown" </td> </tr>
 
+<tr> <td> {client_helo} </td> <td> HELO, MAIL, DATA, EOH, EOM </td> <td> Client HELO value
+</td> </tr>
+
 <tr> <td> {cert_issuer} </td> <td> HELO, MAIL, DATA, EOH, EOM </td> <td>
 TLS client certificate issuer </td> </tr>
 

--- a/postfix/src/global/mail_params.h
+++ b/postfix/src/global/mail_params.h
@@ -3237,7 +3237,7 @@ extern char *var_milt_conn_macros;
 
 #define VAR_MILT_HELO_MACROS		"milter_helo_macros"
 #define DEF_MILT_HELO_MACROS		"{tls_version} {cipher} {cipher_bits}" \
-					" {cert_subject} {cert_issuer}"
+					" {cert_subject} {cert_issuer} {client_helo}"
 extern char *var_milt_helo_macros;
 
 #define VAR_MILT_MAIL_MACROS		"milter_mail_macros"

--- a/postfix/src/milter/milter.h
+++ b/postfix/src/milter/milter.h
@@ -170,6 +170,7 @@ extern void milter_free(MILTERS *);
 #define S8_MAC_CLIENT_PORT	"{client_port}"
 #define S8_MAC_CLIENT_PTR	"{client_ptr}"
 #define S8_MAC_CLIENT_RES	"{client_resolve}"
+#define S8_MAC_CLIENT_HELO	"{client_helo}"
 
 #define S8_MAC_TLS_VERSION	"{tls_version}"
 #define S8_MAC_CIPHER		"{cipher}"

--- a/postfix/src/smtpd/smtpd_milter.c
+++ b/postfix/src/smtpd/smtpd_milter.c
@@ -139,6 +139,13 @@ const char *smtpd_milter_eval(const char *name, void *ptr)
     if (strcmp(name, S8_MAC_CERT_ISSUER) == 0)
 	return (IF_TRUSTED(state->tls_context->issuer_CN));
 #endif
+    if (strcmp(name, S8_MAC_CLIENT_HELO) == 0) {
+	if (state->helo_name == 0)
+	    return (0);
+	if (state->helo_name[0] == 0)
+	    return ("");
+	return (state->helo_name);
+    }
 
     /*
      * MAIL FROM macros.


### PR DESCRIPTION
This macro adds missing functionality to obtain client's HELO value on
any milter stage following the HELO state. This is especially necessary
when XCLIENT is used: so a milter receives helo callback with the
helo/ehlo provided *before* the XCLIENT command, therefore after XCLIENT
is called (along with milter cleanup) there are now ways to receive the
new HELO value. This patch allows to receive it by calling
smfi_getsymval(state, "{client_helo}").

This is not compatible with Sendmail milter API, however, unknown macros
are just ignored by sendmail, so this patch won't likely break sendmail
compatibility.