### PR TITLE
Enable support for Linux 5.x.x kernel

### DIFF
--- a/postfix/makedefs
+++ b/postfix/makedefs
@@ -557,7 +557,7 @@ EOF
 		: ${SHLIB_ENV="LD_LIBRARY_PATH=`pwd`/lib"}
 		: ${PLUGIN_LD="${CC-gcc} -shared"}
 		;;
-  Linux.[34].*)	SYSTYPE=LINUX$RELEASE_MAJOR
+  Linux.[345].*)	SYSTYPE=LINUX$RELEASE_MAJOR
 		case "$CCARGS" in
 		 *-DNO_DB*) ;;
 		 *-DHAS_DB*) ;;

--- a/postfix/src/util/sys_defs.h
+++ b/postfix/src/util/sys_defs.h
@@ -749,7 +749,7 @@ extern int initgroups(const char *, int);
  /*
   * LINUX.
   */
-#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4)
+#if defined(LINUX2) || defined(LINUX3) || defined(LINUX4) || defined(LINUX5)
 #define SUPPORTED
 #define UINT32_TYPE	unsigned int
 #define UINT16_TYPE	unsigned short


### PR DESCRIPTION
Now that 5.x.x is in mainline, compilation will fail due to hard coded checks that cap at the 4.x.x major version

ATTENTION:
ATTENTION: Unknown system type: Linux 5.0.0-rc3-20190120.1740MST
ATTENTION:

These patches enable the 5.x.x major version within these checks