### PR TITLE
Update qmgr_feedback.c

### DIFF
--- a/postfix/src/qmgr/qmgr_feedback.c
+++ b/postfix/src/qmgr/qmgr_feedback.c
@@ -109,7 +109,7 @@ void    qmgr_feedback_init(QMGR_FEEDBACK *fb,
     double  enum_val;
     char    denom_str[30 + 1];
     double  denom_val;
-    char    slash;
+    char    slash[2];
     char    junk;
     char   *fbck_name;
     char   *fbck_val;


### PR DESCRIPTION
Sscanf :The space for output parameters is insufficient

%1[/]
Matches  a nonempty sequence of characters from the specified set of accepted char‐
acters; the next pointer must be a pointer to char, and there must be  enough  room
for all the characters in the string, plus a terminating null byte.