### PR TITLE
Fixing closefrom() compile error in v3.6.4, when using glibc-2.34

### DIFF
--- a/postfix/src/util/sys_defs.h
+++ b/postfix/src/util/sys_defs.h
@@ -827,6 +827,9 @@ extern int initgroups(const char *, int);
 #define HAVE_POSIX_GETPW_R
 #endif
 #endif
+#if HAVE_GLIBC_API_VERSION_SUPPORT(2, 34)
+#define HAS_CLOSEFROM
+#endif
 
 #endif
 


### PR DESCRIPTION
The fix that was applied to the main branch was missing from v3.6.4