### PR TITLE
use multiple bits int the xsasl server - tls_flag - for passing that the

### DIFF
--- a/postfix/src/smtpd/smtpd_sasl_glue.c
+++ b/postfix/src/smtpd/smtpd_sasl_glue.c
@@ -222,7 +222,8 @@ void    smtpd_sasl_activate(SMTPD_STATE *state, const char *sasl_opts_name,
      * Set up a new server context for this connection.
      */
 #ifdef USE_TLS
-    tls_flag = state->tls_context != 0;
+    tls_flag = state->tls_context != 0 ;
+    tls_flag |= (state->tls_context && TLS_CERT_IS_TRUSTED(state->tls_context))?2:0;
 #else
     tls_flag = 0;
 #endif

--- a/postfix/src/xsasl/xsasl_dovecot_server.c
+++ b/postfix/src/xsasl/xsasl_dovecot_server.c
@@ -684,6 +684,8 @@ int     xsasl_dovecot_server_first(XSASL_SERVER *xp, const char *sasl_method,
 	if (server->tls_flag)
 	    /* XXX Encapsulate for logging. */
 	    vstream_fputs("\tsecured", server->impl->sasl_stream);
+	if (server->tls_flag & 2)
+	    vstream_fputs("\tvalid-client-cert", server->impl->sasl_stream);
 	if (init_response) {
 
 	    /*


### PR DESCRIPTION
client ssl certificate was validated. Use this in the dovecot xsasl
server to pass 'valid-client-cert' indicating the checked certificate
to the dovecot authentication server.